### PR TITLE
[#9] 쇼카드 화면 스타일링

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
           else {
               var name = document.getElementById("name").innerHTML
               var price = document.getElementById("price").innerHTML
-              var content = price + " " + name;
+              var content = name + " " + price;
 
               euphy.setCode(content);
               console.log(content);

--- a/index.html
+++ b/index.html
@@ -137,7 +137,6 @@
                 id="name"
                 class="name"
                 style="
-                margin: 0 0 0 0;
                 width: 980px; 
                 height: 150px; 
                 font-size: 100px;
@@ -152,7 +151,6 @@
                 id="price"
                 class="price"
                 style="
-                margin: 0 0 0 0;
                 width: 980px; 
                 height: 200px; 
                 font-size: 125px;

--- a/index.html
+++ b/index.html
@@ -122,26 +122,48 @@
       <div id="showcardSide">
         <center>
           <h1 class="title"> wave-show-card project </h1>
-              <button
-                id='wave_btn' 
-                class='wave_btn' 
-                type='button' 
+            <button
+              id='wave_btn' 
+              class='wave_btn' 
+              type='button' 
+              style="
+              width: 1050px;
+              height: 395px;
+              background-color: white;
+            "
+              onclick='generateSoundData()' 
+            >
+              <div
+                id="name"
+                class="name"
                 style="
-                width: 1050px;
-                height: 395px;
+                margin: 0 0 0 0;
+                width: 980px; 
+                height: 150px; 
+                font-size: 100px;
+                background-color: #87CEFA;
+                color: black;
+                text-align: left;
               "
-                onclick='generateSoundData()' 
               >
-                <div
-                  id="price"
-                  class="price"
-                >
-                </div>
-                <div
-                  id="name"
-                  class="name">
-                </div>
-              </button>
+              상품명
+              </div>
+              <div
+                id="price"
+                class="price"
+                style="
+                margin: 0 0 0 0;
+                width: 980px; 
+                height: 200px; 
+                font-size: 125px;
+                background-color:#F0F8FF;
+                color: black;
+                text-align: right;
+              "
+              >
+              가격
+              </div>
+            </button>
           <div class='desc'>
               <strong>시각 장애인을 위한 음파 송신 웹 쇼카드입니다. 음파 수신 앱으로 웹 쇼카드의 내용을 수신하고 내용을 들을 수 있습니다.</strong><br />
           </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
           else {
               var name = document.getElementById("name").innerHTML
               var price = document.getElementById("price").innerHTML
-              var content = name + " " + price;
+              var content = name + "," + price;
 
               euphy.setCode(content);
               console.log(content);


### PR DESCRIPTION
쇼카드 화면 스타일링을 진행했습니다. 쇼카드의 색상은 전체적인 서비스와 동일하게 파란색으로 제작했습니다. 피드백이 있다면 반영하겠습니다.
<img width="1101" alt="스크린샷 2022-07-29 오후 7 53 22" src="https://user-images.githubusercontent.com/60066586/181744549-d8e30c76-f0ed-4bda-9dfc-c00bb18e1945.png">


추가로 쇼카드의 데이터는 안드로이드 앱에 "name price"의 형식으로 전송됩니다. 
아무런 데이터도 입력되지 않았다면, "상품명 가격"으로 전송되므로 예외처리가 필요합니다.